### PR TITLE
#16 redefined metrics records list object, added serialization

### DIFF
--- a/adsmsg/metrics_record.py
+++ b/adsmsg/metrics_record.py
@@ -23,7 +23,15 @@ class MetricsRecord(Msg):
                 
 
 
-class MetricsRecordList(Msg):
+class MetricsRecordList():
     
-    def __init__(self, *args, **kwargs):        
-        super(MetricsRecordList, self).__init__(metrics_pb2.MetricsRecordList(), args, kwargs)
+    def __init__(self, metrics_records):
+        instance = metrics_pb2.MetricsRecordList()
+        self.__dict__['_data'] = instance  
+        for current in metrics_records:
+            tmp = MetricsRecord(**current)
+            current_protobuf = tmp.__dict__['_data']
+            instance.metrics_records.extend([current_protobuf])
+
+        self.__dict__['metrics_records'] = instance.metrics_records     
+        

--- a/adsmsg/tests/test_metrics_record.py
+++ b/adsmsg/tests/test_metrics_record.py
@@ -1,6 +1,6 @@
 
 import unittest
-from adsmsg.metrics_record import MetricsRecord
+from adsmsg.metrics_record import MetricsRecord, MetricsRecordList
 from datetime import datetime
 import time
 
@@ -78,7 +78,16 @@ class TestMsg(unittest.TestCase):
             for key in t[i]:
                 self.assertEqual(t[i][key], getattr(p[i], key), 'rn_citation_data field {}'.format(key))
 
-                        
-
+    def test_record_list(self):
+        """simple test for test MetricsRecordList"""
+        metrics_data1 = metrics_data = {'bibcode': '1954PhRv...93..256R', 'id': 1, 'refereed': True}                 
+        metrics_data2 = metrics_data = {'bibcode': '1954PhRv...93..256M', 'id': 2, 'refereed': False}
+        metrics_list = [metrics_data1, metrics_data2]                 
+        m = MetricsRecordList(metrics_list)
+        self.assertEqual(len(metrics_list), len(m.metrics_records))
+        for i in range(0, len(metrics_list)):
+            self.assertEqual(metrics_list[i]['bibcode'], m.metrics_records[i].bibcode)
+            self.assertEqual(metrics_list[i]['refereed'], m.metrics_records[i].refereed)
+        
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The changes to adsmsg.metrics_records.MetricsRecordList may be controversial because the class does not inherit from Msg.  Should I use another approach for dealing with lists?

the object for the list of metrics records no longer subclasses Msg.  the __init__ method accepts a list of dicts where each dict defines a full metrics record for a bibcode.  it creates a metrics_pb2.MetricsRecordList which holds a list of MetricRecord objects.