### PR TITLE
add functions to create wrappers from protobufs

### DIFF
--- a/adsmsg/metrics_record.py
+++ b/adsmsg/metrics_record.py
@@ -1,5 +1,7 @@
 from .msg import Msg
 from .protobuf import metrics_pb2
+from google.protobuf.json_format import MessageToJson
+import json
 
 # wrapper classes for metrics protobufs
 
@@ -34,3 +36,12 @@ class MetricsRecordList(Msg):
         super(MetricsRecordList, self).__init__(metrics_pb2.MetricsRecordList(), args, kwargs)
     
            
+def protobufToMetricsRecord(pbuf):
+    """use with elements in MetricsRecordList.metrics_records
+
+    converts metricsrecord_pb2.MetricsRecord to our MetricsRecord wrapper
+    """
+    tmp_string = MessageToJson(pbuf)
+    tmp_dict = json.loads(tmp_string)
+    tmp_metrics = MetricsRecord(**tmp_dict)
+    return tmp_metrics

--- a/adsmsg/nonbibrecord.py
+++ b/adsmsg/nonbibrecord.py
@@ -1,5 +1,7 @@
 from .msg import Msg
 from .protobuf import nonbibrecord_pb2
+from google.protobuf.json_format import MessageToJson
+import json
 
 class NonBibRecord(Msg):
 
@@ -10,5 +12,19 @@ class NonBibRecord(Msg):
 class NonBibRecordList(Msg):
 
     def __init__(self, *args, **kwargs):
+        if 'nonbib_records' in kwargs:
+            tmp = [NonBibRecord(**x)._data for x in kwargs['nonbib_records']]
+            kwargs['metrics_records'] = tmp
         super(NonBibRecordList, self).__init__(nonbibrecord_pb2.NonBibRecordList(), args, kwargs)
+
+
+def protobufToNonBibRecord(pbuf):
+    """use with elements in NonBibRecordList.nonbib_records
+
+    converts nonbibrecord_pb2.NonBibRecord to our NonBibRecord wrapper
+    """
+    tmp_string = MessageToJson(pbuf)
+    tmp_dict = json.loads(tmp_string)
+    tmp_nonbib = NonBibRecord(**tmp_dict)
+    return tmp_nonbib
 

--- a/adsmsg/tests/test_metrics_record.py
+++ b/adsmsg/tests/test_metrics_record.py
@@ -1,6 +1,6 @@
 
 import unittest
-from adsmsg.metrics_record import MetricsRecord, MetricsRecordList
+from adsmsg.metrics_record import MetricsRecord, MetricsRecordList, protobufToMetricsRecord
 from datetime import datetime
 import time
 from json import dumps, loads
@@ -109,6 +109,20 @@ class TestMsg(unittest.TestCase):
         for i in range(0, len(metrics_list)):
             self.assertEqual(metrics_list[i]['bibcode'], m.metrics_records[i].bibcode)
             self.assertEqual(metrics_list[i]['refereed'], m.metrics_records[i].refereed)
+
+    def test_list_wrapper(self):
+        metrics_data1 = metrics_data = {'bibcode': '1954PhRv...93..256R', 'refereed': True}
+        metrics_data2 = metrics_data = {'bibcode': '1954PhRv...93..256M', 'refereed': False}
+        metrics_list = [metrics_data1, metrics_data2]
+        m = MetricsRecordList(metrics_records=metrics_list)
+
+        count = 0
+        for current in m.metrics_records:
+            wrapper = protobufToMetricsRecord(current)
+            self.assertEqual(wrapper.bibcode, metrics_list[count]['bibcode'])
+            self.assertEqual(wrapper.refereed, metrics_list[count]['refereed'])
+            count += 1
+
 
 
 

--- a/adsmsg/tests/test_nonbibcode_record.py
+++ b/adsmsg/tests/test_nonbibcode_record.py
@@ -1,6 +1,6 @@
 
 import unittest
-from adsmsg.nonbibrecord import NonBibRecord
+from adsmsg.nonbibrecord import NonBibRecord, NonBibRecordList, protobufToNonBibRecord
 
 class TestMsg(unittest.TestCase):
 
@@ -11,7 +11,7 @@ class TestMsg(unittest.TestCase):
         unittest.TestCase.tearDown(self)
 
 
-    def test(self):
+    def test_record(self):
         nonbib_data = {'bibcode': '2003ASPC..295..361M', 'refereed': False,
                        'downloads': [0,0], 'boost': 3.1,
                        'reads': [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]}
@@ -21,6 +21,23 @@ class TestMsg(unittest.TestCase):
         self.assertEqual(m.downloads, nonbib_data['downloads'])
         self.assertEqual(m.reads, nonbib_data['reads'])
         self.assertAlmostEqual(m.boost, nonbib_data['boost'], places=5)
+
+
+    def test_list(self):
+        nonbib_data1 = {'bibcode': '2003ASPC..295..361M', 'refereed': False}
+        nonbib_data2 = {'bibcode': '2003ASPC..295..361Z', 'refereed': True}
+        n1 = NonBibRecord(**nonbib_data1)
+        n2 = NonBibRecord(**nonbib_data2)
+        n_wrapper = [n1, n2]
+        n_pbuf = [n1._data, n2._data]
+        l = NonBibRecordList()
+        l.nonbib_records.extend(n_pbuf)
+        count = 0
+        for current in l.nonbib_records:
+            wrapper = protobufToNonBibRecord(current)
+            self.assertEqual(wrapper.bibcode, n_wrapper[count].bibcode)
+            self.assertEqual(wrapper.refereed, n_wrapper[count].refereed)
+            count += 1
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
when interating over lists in NonBibRecordsList or MetricsList the application code get protobuf objects that need to be converted to wrapper objects.

Am I missing something?  When the master pipeline is dealing with a list object (repeated field), the objects in the list are raw protobus. It must create wrapper objects to hand off to existing code.  IF there's already a way to do this, the new function protobufToNonBibRecord and protobufToMetricsRecord are not needed.