### PR TITLE
support for default values in json representation

### DIFF
--- a/adsmsg/msg.py
+++ b/adsmsg/msg.py
@@ -90,11 +90,13 @@ class Msg(object):
         return self._data
 
 
-    def toJSON(self, return_string=False):
+    def toJSON(self, return_string=False, including_default_value_fields=False):
         if return_string:
-            return json_format.MessageToJson(self.__dict__['_data'])
+            return json_format.MessageToJson(self.__dict__['_data'], 
+                                             including_default_value_fields=including_default_value_fields)
         return json_format.MessageToDict(self.__dict__['_data'],
-                    preserving_proto_field_name=True)
+                    preserving_proto_field_name=True, 
+                                         including_default_value_fields=including_default_value_fields)
 
 
     def __json__(self):

--- a/adsmsg/tests/test_metrics_record.py
+++ b/adsmsg/tests/test_metrics_record.py
@@ -42,7 +42,37 @@ class TestMsg(unittest.TestCase):
             else:
                 self.assertEqual(getattr(m, key), metrics_data[key])
         self.verify_json(m, 'simple test')
-    
+
+    def test_json_defaults(self):
+        """test filling in default values in json"""
+
+        # use some very incomplete test data
+        metrics_data = {'bibcode': '1954PhRv...93..256R'}
+        m = MetricsRecord(**metrics_data)
+
+        # verify default values not added by default
+        j = m.toJSON()
+        # verify a default values was not added
+        self.assertRaises(KeyError, lambda: j['refereed'])
+
+        # now verify defaults are added when requested
+        j = m.toJSON(including_default_value_fields=True)
+        self.assertEqual(0, j['an_citations'])
+        self.assertEqual(0, j['an_refereed_citations'])
+        self.assertEqual(0, j['author_num'])
+        self.assertEqual(0, j['citation_num'])
+        self.assertEqual(0, len(j['citations']))
+        self.assertEqual(0, len(j['downloads']))
+        self.assertEqual(0, len(j['reads']))
+        self.assertFalse(j['refereed'])
+        self.assertEqual(0, j['refereed_citation_num'])
+        self.assertEqual(0, len(j['refereed_citations']))
+        self.assertEqual(0, j['reference_num'])
+        self.assertEqual(0, j['rn_citations'])
+        self.assertEqual(0, len(j['rn_citation_data']))
+        self.assertEqual(0, len(j['rn_citations_hist']))
+
+
     def verify_json(self, metrics_record, message):
         j = metrics_record.toJSON()
         test = loads(dumps(j))


### PR DESCRIPTION
to improve performance, protobuf 3 does not put default values on the wire.  to improve usability, they can be optionally added to the json representation.  this change makes that feature visible.  it is expected to be useful for metrics code that wants a complete record that includes all values, see https://app.zenhub.com/workspace/o/adsabs/adsmasterpipeline/issues/22

relevant protobuf code is at https://github.com/google/protobuf/blob/master/python/google/protobuf/json_format.py#L121

required for PR to ADSMasterPipeline