### PR TITLE
fix pypi long description rendering error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     author='NASA/SAO ADS',
     description='Interpipeline communication messages',
     long_description=__doc__,
+    long_description_content_type='text/markdown',
     packages=find_packages(),
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
This is to fix the error mesage: `HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText` when trying the command `twine upload dist/*`

Solution to this issue is also mentioned [here](https://github.com/pypa/warehouse/issues/5890#issuecomment-494868157) 