### PR TITLE
Protobuf relative imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,19 @@ and the protocol buffers should be compiled from the specs directory with:
 
 ```
 protoc --python_out=../adsmsg/protobuf filename.proto
+# protoc does not express imports in a relative form, which messes up with our package structure
+# thus we force relative imports by changing the generated files with the next sed command:
+# 	https://github.com/protocolbuffers/protobuf/issues/1491#issuecomment-369324250
+sed -i 's/^import \([^ ]*\)_pb2 as \([^ ]*\)$/from . import \1_pb2 as \2/' ../adsmsg/protobuf/*_pb2.py
 ```
 
 Alternatively, a docker container can be built:
 
 ```
 docker build -t adsmsg .
-docker run -it --name adsmsg adsmsg
+docker run --rm -v `pwd`:/app --name adsmsg adsmsg make
 ```
+
 Or better, just run:
 
 ```

--- a/adsmsg/protobuf/metrics_pb2.py
+++ b/adsmsg/protobuf/metrics_pb2.py
@@ -12,7 +12,7 @@ _sym_db = _symbol_database.Default()
 
 
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
-import status_pb2 as status__pb2
+from . import status_pb2 as status__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -7,5 +7,4 @@ if [ "`docker images adsmsg | grep adsmsg`" = "" ]; then
     #docker run -it --name adsmsg adsmsg
 fi
 
-docker rm adsmsg
-docker run -v `pwd`:/app --name adsmsg adsmsg make
+docker run --rm -v `pwd`:/app --name adsmsg adsmsg make

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -1,6 +1,10 @@
 
 files = $(shell find . -iname '*.proto')
 all:
-	python -c "import os,glob; [os.system('protoc --python_out=../adsmsg/protobuf {file}'.format(file=x)) for x in glob.glob('*.proto')]"
+	python3 -c "import os,glob; [os.system('protoc --python_out=../adsmsg/protobuf/ {file}'.format(file=x)) for x in glob.glob('*.proto')]"
+	# protoc does not express imports in a relative form, which messes up with our package structure
+	# thus we force relative imports by changing the generated files with the next sed command:
+	# 	https://github.com/protocolbuffers/protobuf/issues/1491#issuecomment-369324250
+	sed -i 's/^import \([^ ]*\)_pb2 as \([^ ]*\)$$/from . import \1_pb2 as \2/' ../adsmsg/protobuf/*_pb2.py
 clean:
-	python -c "import os,glob; [os.system('rm -fr ../adsmsg/protobuf/{file}_pb2.py*'.format(file=x.split('.proto')[0])) for x in glob.glob('*.proto')]"
+	python3 -c "import os,glob; [os.system('rm -fr ../adsmsg/protobuf/{file}_pb2.py*'.format(file=x.split('.proto')[0])) for x in glob.glob('*.proto')]"


### PR DESCRIPTION
protoc does not express imports in a relative form, which messes up with our package structure, thus we force relative imports by changing the generated files with the sed command