### PR TITLE
Bugfix: sed permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,11 @@ WORKDIR /app
 RUN pip install -r requirements.txt && \
     pip3 install -r requirements.txt
 
+# -Install a newer version of sed to fix issue with sed -i not handling permissions properly
+RUN wget https://ftp.gnu.org/gnu/sed/sed-4.9.tar.gz && \
+    tar -xzvf sed-4.9.tar.gz && \
+    cd sed-4.9/ && \
+    ./configure && make install
+
 CMD /bin/bash
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Message definitions based on [Google Protocol Buffers](https://developers.google
 
 ## Development
 
-To modify message definition, Protocol Buffers compiler should be installed:
+#### To modify message definition, Protocol Buffers compiler should be installed:
 
 ```
 sudo apt-get install autoconf automake libtool curl make g++ unzip
@@ -33,12 +33,16 @@ protoc --python_out=../adsmsg/protobuf filename.proto
 # 	https://github.com/protocolbuffers/protobuf/issues/1491#issuecomment-369324250
 sed -i 's/^import \([^ ]*\)_pb2 as \([^ ]*\)$/from . import \1_pb2 as \2/' ../adsmsg/protobuf/*_pb2.py
 ```
+MacOS users may find they need to replace the `sed` command with:
+```
+sed -i '' -e 's/^import \([^ ]*\)_pb2 as \([^ ]*\)$/from . import \1_pb2 as \2/' ../adsmsg/protobuf/*_pb2.py
+```
+due to differences in how the `BSD` version of `sed` operates compared to the `GNU` version bundled with most Linux distributions.
 
-Alternatively, a docker container can be built:
+ #### Alternatively, a docker container can be built:
 
 ```
-docker build -t adsmsg .
-docker run --rm -v `pwd`:/app --name adsmsg adsmsg make
+docker-compose up -d --force-recreate
 ```
 
 Or better, just run:
@@ -47,7 +51,19 @@ Or better, just run:
 ./rebuild.sh
 ```
 
-Every time the protocol buffers specifications are changed.
+`docker-compose` will automatically build the image if it does not already exist. If you wish to rebuild the image manually, simply
+
+```bash
+docker-compose build
+```
+or
+
+```bash
+docker-compose up --build
+```
+The `--no-cache` flag can be added to stop `docker` from using the cache for the build.
+
+Regardless of the chosen path, this must be run every time the protocol buffers specifications are changed.
 
 
 ### Testing

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: '3.1'
+services:
+  adsmsg:
+    build: .
+    image: adsmsg:latest
+    container_name: adsmsg
+    volumes:
+     - ./:/app
+    networks:
+      - adsmsg
+    stdin_open: true
+    tty: true
+    entrypoint: make
+networks:
+  adsmsg:
+    driver: bridge

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -2,9 +2,4 @@
 set -x
 set -e
 
-if [ "`docker images adsmsg | grep adsmsg`" = "" ]; then
-    docker build -t adsmsg .
-    #docker run -it --name adsmsg adsmsg
-fi
-
-docker run --rm -v `pwd`:/app --name adsmsg adsmsg make
+docker-compose up --force-recreate

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -5,6 +5,6 @@ all:
 	# protoc does not express imports in a relative form, which messes up with our package structure
 	# thus we force relative imports by changing the generated files with the next sed command:
 	# 	https://github.com/protocolbuffers/protobuf/issues/1491#issuecomment-369324250
-	sed -i 's/^import \([^ ]*\)_pb2 as \([^ ]*\)$$/from . import \1_pb2 as \2/' ../adsmsg/protobuf/*_pb2.py
+	/usr/local/bin/sed -i 's/^import \([^ ]*\)_pb2 as \([^ ]*\)$$/from . import \1_pb2 as \2/' ../adsmsg/protobuf/*_pb2.py
 clean:
 	python3 -c "import os,glob; [os.system('rm -fr ../adsmsg/protobuf/{file}_pb2.py*'.format(file=x.split('.proto')[0])) for x in glob.glob('*.proto')]"


### PR DESCRIPTION
`sed` versions `>=4.2.1<4.8`* do not handle temporary file permissions properly when using bind mounted volumes in `docker` This PR:
- Installs `sed-v4.9`
- Updates `specs/Makefile` to use the newer version of `sed`
- Migrates `rebuild.sh` to use `docker-compose` to make debugging and interactive container management easier.